### PR TITLE
2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,12 @@ $ npm install --save-dev rollup-analyzer
 ## Usage
 
 ```js
-const rollupAnalyzer = require('rollup-analyzer')({limit: 5})
-rollup.rollup({/*...*/}).then((bundle) => {
+import { rollup } from 'rollup'
+const { formatted } from 'rollup-analyzer'
+
+rollup({/*...*/}).then((bundle) => {
   // print console optimized analysis string
-  rollupAnalyzer.formatted(bundle).then(console.log).catch(console.error)
+  formatted(bundle, {limit: 5}).then(console.log).catch(console.error)
 })
 
 // Results in ...
@@ -59,12 +61,27 @@ dependents: 1
 
 ## API
 
-### rollupAnalyzer
-the default exported function is identical to init, and returns the same functions as export {init, formatted, analyze}. So, you can `require('rollup-analyzer')` or `require('rollup-analyzer')({limit: 5})` and use the same functions.
+Module exports `analyze`, `formatted`, and `plugin` functions
 
-### rollupAnalyzer.init(options)
-set options to use in analysis (this step is optional)
-- **options** *(Object)*
+### formatted(bundle, options)
+- arguments
+  - **bundle** *(Rollup Bundle)*
+  - **options** *(Object - see below for available options)*
+- returns
+  - **analysisText** *(String - well formatted for console printing)*
+
+### analyze(bundle, options)
+- arguments
+  - **bundle** *(Rollup Bundle)*
+  - **options** *(Object - see below for available options)*
+- returns
+  - **analysis** *(Object)*
+    - **id** *(String)* - path of module / rollup module id
+    - **size** *(Number)* - size of module in bytes
+    - **dependents** *(Array)* - list of dependent module ids / paths
+    - **percent** *(Number)* - percentage of module size relative to entire bundle
+
+#### options `Object`
   - **limit** - *optional*
     - type: Number
     - default: `null`
@@ -77,20 +94,6 @@ set options to use in analysis (this step is optional)
     - type: String
     - default: `process.cwd()`
     - description: Application directory, used to display file paths relatively
-
-### rollupAnalyzer.formatted(bundle)
-returns Promise which resolves with well formatted analysis string (for CLI printing)
-- **bundle** *(Rollup Bundle)* - *required*
-
-### rollupAnalyzer.analyze(bundle)
-returns Promise which resolves with array of objects describing each imported file
-- **bundle** *(Rollup Bundle)* - *required*
-
-returned array's child analysis objects have the following properties
-- **id** *(String)* - path of module / rollup module id
-- **size** *(Number)* - size of module in bytes
-- **dependents** *(Array)* - list of dependent module ids / paths
-- **percent** *(Number)* - percentage of module size relative to entire bundle
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -22,8 +22,8 @@ const analyze = (bundle, opts = {}, format = false) => {
 
   return new Promise((resolve, reject) => {
     if (bundleModules && !Array.isArray(bundleModules)) {
-      bundleModules = Object.entries(bundleModules).map(([id, obj]) => {
-        let { originalLength, renderedLength } = obj;
+      bundleModules = Object.keys(bundleModules).map((id) => {
+        let { originalLength, renderedLength } = bundleModules[id];
         return {id, dependencies: [], originalLength, renderedLength}
       });
     }

--- a/index.js
+++ b/index.js
@@ -1,14 +1,10 @@
 'use strict';
 
-// Setup
+Object.defineProperty(exports, '__esModule', { value: true });
+
 const buf = ' ';
 const tab = '  ';
 const borderX = `${Array(30).join('-')}\n`;
-let proc = process;
-let root = proc && proc.cwd ? proc.cwd() : null;
-let limit, filter;
-
-// Helpers
 const formatBytes = (bytes) => {
   if (bytes === 0) return '0 Byte'
   let k = 1000;
@@ -18,51 +14,42 @@ const formatBytes = (bytes) => {
   return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i]
 };
 
-// Main
-function init (opts) {
-  opts = opts || {};
-  limit = opts.limit;
-  filter = opts.filter;
-  root = opts.root || root;
-}
-
-function analyzer (opts) {
-  init(opts);
-  return {init, formatted, analyze}
-}
-analyzer.init = init;
-analyzer.formatted = formatted;
-analyzer.analyze = analyze;
-
-function formatted (bndl) { return analyze(bndl, true) }
-
-function analyze (bundle, format) {
+const analyze = (bundle, opts = {}, format = false) => {
+  let { root, limit, filter } = opts;
   let deps = {};
   let bundleSize = 0;
+
   return new Promise((resolve, reject) => {
     let modules = bundle.modules.map((m, i) => {
       let id = m.id.replace(root, '');
       let size = Buffer.byteLength(m.code, 'utf8') || 0;
       bundleSize += size;
+
       if (Array.isArray(filter) && !filter.some((f) => id.match(f))) return null
-      else if (typeof filter === 'string' && !id.match(filter)) return null
+      if (typeof filter === 'string' && !id.match(filter)) return null
+
       m.dependencies.forEach((d) => {
         d = d.replace(root, '');
         deps[d] = deps[d] || [];
         deps[d].push(id);
       });
+
       return {id, size}
     }).filter((m) => m);
+
     modules.sort((a, b) => b.size - a.size);
     if (limit || limit === 0) modules = modules.slice(0, limit);
     modules.forEach((m) => {
       m.dependents = deps[m.id] || [];
       m.percent = ((m.size / bundleSize) * 100).toFixed(2);
     });
+
     if (!format) return resolve(modules)
+
     let heading = `Rollup File Analysis\n`;
     let displaySize = `${borderX}bundle size: ${formatBytes(bundleSize)}\n`;
     let formatted = `${borderX}${heading}${displaySize}${borderX}`;
+
     modules.forEach((m) => {
       formatted += `file:${buf}${m.id}\n`;
       formatted += `size:${buf}${formatBytes(m.size)}\n`;
@@ -73,8 +60,12 @@ function analyze (bundle, format) {
       });
       formatted += `${borderX}`;
     });
+
     return resolve(formatted)
   })
-}
+};
 
-module.exports = analyzer;
+const formatted = (bndl, opts) => analyze(bndl, opts, true);
+
+exports.analyze = analyze;
+exports.formatted = formatted;

--- a/index.js
+++ b/index.js
@@ -18,11 +18,19 @@ const analyze = (bundle, opts = {}, format = false) => {
   let { root, limit, filter } = opts;
   let deps = {};
   let bundleSize = 0;
+  let bundleModules = bundle.modules;
 
   return new Promise((resolve, reject) => {
-    let modules = bundle.modules.map((m, i) => {
+    if (bundleModules && !Array.isArray(bundleModules)) {
+      bundleModules = Object.entries(bundleModules).map(([id, obj]) => {
+        let { originalLength, renderedLength } = obj;
+        return {id, dependencies: [], originalLength, renderedLength}
+      });
+    }
+
+    let modules = bundleModules.map((m, i) => {
       let id = m.id.replace(root, '');
-      let size = Buffer.byteLength(m.code, 'utf8') || 0;
+      let size = m.renderedLength || Buffer.byteLength(m.code, 'utf8') || 0;
       bundleSize += size;
 
       if (Array.isArray(filter) && !filter.some((f) => id.match(f))) return null
@@ -68,12 +76,20 @@ const analyze = (bundle, opts = {}, format = false) => {
 const formatted = (bndl, opts) => analyze(bndl, opts, true);
 
 const plugin = (opts = {}) => {
-  let log = opts.writeTo || (opts.stdout ? console.log : console.error);
+  let cb = opts.writeTo || (opts.stdout ? console.log : console.error);
+  if (opts.onAnalysis) cb = opts.onAnalysis;
+  let written;
+
+  let runAnalysis = (outputOptions, bundle, isWrite) => {
+    if (written) return
+    if (outputOptions.bundle) bundle = outputOptions.bundle;
+    written = true;
+    return analyze(bundle, opts, !opts.onAnalysis).then(cb)
+  };
   return {
     name: 'rollup-analyzer-plugin',
-    ongenerate: ({bundle}) => {
-      return formatted(bundle, opts).then(log)
-    }
+    generateBundle: runAnalysis,
+    ongenerate: runAnalysis
   }
 };
 

--- a/index.js
+++ b/index.js
@@ -17,23 +17,17 @@ const formatBytes = (bytes) => {
 const analyze = (bundle, opts = {}, format = false) => {
   let { root, limit, filter } = opts;
   let deps = {};
+  let entrySize;
   let bundleSize = 0;
   let bundleModules = bundle.modules;
 
   return new Promise((resolve, reject) => {
-    if (bundleModules && !Array.isArray(bundleModules)) {
-      bundleModules = Object.keys(bundleModules).map((id) => {
-        let { originalLength, renderedLength } = bundleModules[id];
-        return {id, dependencies: [], originalLength, renderedLength}
-      });
-    }
-
     let modules = bundleModules.map((m, i) => {
-      let id = m.id.replace(root, '');
-      let size = m.renderedLength;
-      if (!size && size !== 0) {
-        size = m.code ? Buffer.byteLength(m.code, 'utf8') : 0;
-      }
+      let { id, originalLength: origSize, renderedLength, isEntry, code } = m;
+      id = id.replace(root, '');
+      let size = renderedLength;
+      if (!size && size !== 0) size = code ? Buffer.byteLength(code, 'utf8') : 0;
+      if (isEntry) entrySize = size;
       bundleSize += size;
 
       if (Array.isArray(filter) && !filter.some((f) => id.match(f))) return null
@@ -45,14 +39,17 @@ const analyze = (bundle, opts = {}, format = false) => {
         deps[d].push(id);
       });
 
-      return {id, size}
+      return {id, size, origSize, isEntry}
     }).filter((m) => m);
+
+    if (entrySize) bundleSize = entrySize;
 
     modules.sort((a, b) => b.size - a.size);
     if (limit || limit === 0) modules = modules.slice(0, limit);
     modules.forEach((m) => {
       m.dependents = deps[m.id] || [];
       m.percent = ((m.size / bundleSize) * 100).toFixed(2);
+      m.reduction = 100 - ((m.size / m.origSize) * 100).toFixed(2);
     });
 
     if (!format) return resolve(modules)
@@ -62,9 +59,12 @@ const analyze = (bundle, opts = {}, format = false) => {
     let formatted = `${borderX}${heading}${displaySize}${borderX}`;
 
     modules.forEach((m) => {
+      if (m.isEntry) return
       formatted += `file:${buf}${m.id}\n`;
       formatted += `size:${buf}${formatBytes(m.size)}\n`;
       formatted += `percent:${buf}${m.percent}%\n`;
+      formatted += `orig. size:${buf}${formatBytes(m.origSize || 'unknown')}\n`;
+      formatted += `code reduction:${buf}${m.reduction}%\n`;
       formatted += `dependents:${buf}${m.dependents.length}\n`;
       m.dependents.forEach((d) => {
         formatted += `${tab}-${buf}${d.replace(root, '')}\n`;
@@ -82,15 +82,39 @@ const plugin = (opts = {}) => {
   let cb = opts.writeTo || (opts.stdout ? console.log : console.error);
   if (opts.onAnalysis) cb = opts.onAnalysis;
   let written;
+  let modules;
 
-  let runAnalysis = (outputOptions, bundle, isWrite) => {
+  let runAnalysis = (out, bundle, isWrite) => new Promise((resolve, reject) => {
+    resolve();
     if (written) return
-    if (outputOptions.bundle) bundle = outputOptions.bundle;
     written = true;
-    return analyze(bundle, opts, !opts.onAnalysis).then(cb)
-  };
+    if (out.bundle) bundle = out.bundle;
+    if (!Array.isArray(bundle.modules)) {
+      modules.forEach((m) => {
+        let bm = bundle.modules[m.id];
+        bm.id = bm.id || m.id;
+        bm.isEntry = bm.isEntry || m.isEntry;
+        bm.dependencies = m.dependencies || [];
+      });
+      modules = Object.keys(bundle.modules).map((k) => bundle.modules[k]);
+    } else {
+      modules = bundle.modules;
+    }
+    return analyze({modules}, opts, !opts.onAnalysis).then(cb)
+  });
   return {
     name: 'rollup-analyzer-plugin',
+    transformChunk: (_a, _b, chunk) => new Promise((resolve, reject) => {
+      resolve(null);
+      if (!chunk || !chunk.orderedModules) return
+      modules = chunk.orderedModules.map((m) => {
+        return {
+          id: m.id,
+          isEntry: m.isEntryPoint,
+          dependencies: m.dependencies.map((d) => d.id)
+        }
+      });
+    }),
     generateBundle: runAnalysis,
     ongenerate: runAnalysis
   }

--- a/index.js
+++ b/index.js
@@ -67,5 +67,16 @@ const analyze = (bundle, opts = {}, format = false) => {
 
 const formatted = (bndl, opts) => analyze(bndl, opts, true);
 
+const plugin = (opts = {}) => {
+  let log = opts.writeTo || (opts.stdout ? console.log : console.error);
+  return {
+    name: 'rollup-analyzer-plugin',
+    ongenerate: ({bundle}) => {
+      return formatted(bundle, opts).then(log)
+    }
+  }
+};
+
 exports.analyze = analyze;
 exports.formatted = formatted;
+exports.plugin = plugin;

--- a/index.js
+++ b/index.js
@@ -30,7 +30,10 @@ const analyze = (bundle, opts = {}, format = false) => {
 
     let modules = bundleModules.map((m, i) => {
       let id = m.id.replace(root, '');
-      let size = m.renderedLength || Buffer.byteLength(m.code, 'utf8') || 0;
+      let size = m.renderedLength;
+      if (!size && size !== 0) {
+        size = m.code ? Buffer.byteLength(m.code, 'utf8') : 0;
+      }
       bundleSize += size;
 
       if (Array.isArray(filter) && !filter.some((f) => id.match(f))) return null

--- a/module.js
+++ b/module.js
@@ -28,7 +28,10 @@ export const analyze = (bundle, opts = {}, format = false) => {
 
     let modules = bundleModules.map((m, i) => {
       let id = m.id.replace(root, '')
-      let size = m.renderedLength || Buffer.byteLength(m.code, 'utf8') || 0
+      let size = m.renderedLength
+      if (!size && size !== 0) {
+        size = m.code ? Buffer.byteLength(m.code, 'utf8') : 0
+      }
       bundleSize += size
 
       if (Array.isArray(filter) && !filter.some((f) => id.match(f))) return null

--- a/module.js
+++ b/module.js
@@ -20,8 +20,8 @@ export const analyze = (bundle, opts = {}, format = false) => {
 
   return new Promise((resolve, reject) => {
     if (bundleModules && !Array.isArray(bundleModules)) {
-      bundleModules = Object.entries(bundleModules).map(([id, obj]) => {
-        let { originalLength, renderedLength } = obj
+      bundleModules = Object.keys(bundleModules).map((id) => {
+        let { originalLength, renderedLength } = bundleModules[id]
         return {id, dependencies: [], originalLength, renderedLength}
       })
     }

--- a/module.js
+++ b/module.js
@@ -64,3 +64,13 @@ export const analyze = (bundle, opts = {}, format = false) => {
 }
 
 export const formatted = (bndl, opts) => analyze(bndl, opts, true)
+
+export const plugin = (opts = {}) => {
+  let log = opts.writeTo || (opts.stdout ? console.log : console.error)
+  return {
+    name: 'rollup-analyzer-plugin',
+    ongenerate: ({bundle}) => {
+      return formatted(bundle, opts).then(log)
+    }
+  }
+}

--- a/module.js
+++ b/module.js
@@ -1,14 +1,8 @@
 'use strict'
 
-// Setup
 const buf = ' '
 const tab = '  '
 const borderX = `${Array(30).join('-')}\n`
-let proc = process
-let root = proc && proc.cwd ? proc.cwd() : null
-let limit, filter
-
-// Helpers
 const formatBytes = (bytes) => {
   if (bytes === 0) return '0 Byte'
   let k = 1000
@@ -18,54 +12,42 @@ const formatBytes = (bytes) => {
   return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i]
 }
 
-// Exports
-export default analyzer
-
-// Main
-function init (opts) {
-  opts = opts || {}
-  limit = opts.limit
-  filter = opts.filter
-  root = opts.root || root
-}
-
-function analyzer (opts) {
-  init(opts)
-  return {init, formatted, analyze}
-}
-analyzer.init = init
-analyzer.formatted = formatted
-analyzer.analyze = analyze
-
-function formatted (bndl) { return analyze(bndl, true) }
-
-function analyze (bundle, format) {
+export const analyze = (bundle, opts = {}, format = false) => {
+  let { root, limit, filter } = opts
   let deps = {}
   let bundleSize = 0
+
   return new Promise((resolve, reject) => {
     let modules = bundle.modules.map((m, i) => {
       let id = m.id.replace(root, '')
       let size = Buffer.byteLength(m.code, 'utf8') || 0
       bundleSize += size
+
       if (Array.isArray(filter) && !filter.some((f) => id.match(f))) return null
-      else if (typeof filter === 'string' && !id.match(filter)) return null
+      if (typeof filter === 'string' && !id.match(filter)) return null
+
       m.dependencies.forEach((d) => {
         d = d.replace(root, '')
         deps[d] = deps[d] || []
         deps[d].push(id)
       })
+
       return {id, size}
     }).filter((m) => m)
+
     modules.sort((a, b) => b.size - a.size)
     if (limit || limit === 0) modules = modules.slice(0, limit)
     modules.forEach((m) => {
       m.dependents = deps[m.id] || []
       m.percent = ((m.size / bundleSize) * 100).toFixed(2)
     })
+
     if (!format) return resolve(modules)
+
     let heading = `Rollup File Analysis\n`
     let displaySize = `${borderX}bundle size: ${formatBytes(bundleSize)}\n`
     let formatted = `${borderX}${heading}${displaySize}${borderX}`
+
     modules.forEach((m) => {
       formatted += `file:${buf}${m.id}\n`
       formatted += `size:${buf}${formatBytes(m.size)}\n`
@@ -76,6 +58,9 @@ function analyze (bundle, format) {
       })
       formatted += `${borderX}`
     })
+
     return resolve(formatted)
   })
 }
+
+export const formatted = (bndl, opts) => analyze(bndl, opts, true)

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "rollup45": "npm:rollup@0.45.x",
     "rollup50": "npm:rollup@0.50.x",
     "rollup55": "npm:rollup@0.55.x",
-    "rollup59": "npm:rollup@0.59.x"
+    "rollup60": "npm:rollup@0.60.x"
   },
   "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rollup-analyzer",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0-beta.3",
   "description": "Analyze file sizes of rollup bundled imports",
   "main": "index.js",
   "module": "module.js",
@@ -35,7 +35,7 @@
   "devDependencies": {
     "ava": "^0.25.0",
     "husky": "^0.14.3",
-    "rollup": "latest",
+    "rollup": "^0.60.1",
     "rollup40": "npm:rollup@0.40.x",
     "rollup45": "npm:rollup@0.45.x",
     "rollup50": "npm:rollup@0.50.x",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rollup-analyzer",
-  "version": "1.1.0",
+  "version": "2.0.0-beta.1",
   "description": "Analyze file sizes of rollup bundled imports",
   "main": "index.js",
   "module": "module.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rollup-analyzer",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "description": "Analyze file sizes of rollup bundled imports",
   "main": "index.js",
   "module": "module.js",

--- a/test/index.js
+++ b/test/index.js
@@ -24,6 +24,7 @@ const expectHeader = `
 Rollup File Analysis
 -----------------------------
 `.trim()
+const headerLength = expectHeader.length
 
 // test against many versions of rollup
 const rollers = [
@@ -37,10 +38,10 @@ const rollers = [
 
 // main
 rollers.forEach(({rollup, version, opts, noTreeshake}) => {
-  test(`${version}: formatted returns string`, async (assert) => {
+  test(`${version}: formatted returns expected string`, async (assert) => {
     let bundle = await rollup(opts)
     let results = await formatted(bundle)
-    assert.is(typeof results, 'string')
+    assert.is(results.substr(0, headerLength), expectHeader)
   })
 
   test(`${version}: analyze returns array`, async (assert) => {

--- a/test/index.js
+++ b/test/index.js
@@ -9,7 +9,7 @@ import { rollup as rollup55 } from 'rollup55'
 import { rollup as rollup50 } from 'rollup50'
 import { rollup as rollup45 } from 'rollup45'
 import { rollup as rollup40 } from 'rollup40'
-import analyzer, { init, formatted, analyze } from './../index'
+import { analyze, formatted } from './../index'
 const fixtures = resolve(__dirname, 'fixtures')
 const baseOpts = {
   input: join(fixtures, 'bundle.js'),
@@ -19,20 +19,6 @@ const oldOpts = {
   entry: join(fixtures, 'bundle.js'),
   format: 'cjs'
 }
-
-// general API conformity tests
-test(`analyzer returns {init, formatted, analyze}`, (assert) => {
-  assert.is(analyzer.init, init)
-  assert.is(analyzer.formatted, formatted)
-  assert.is(analyzer.analyze, analyze)
-})
-
-test(`analyzer() returns {init, formatted, analyze}`, (assert) => {
-  let optedAnalyzer = analyzer()
-  assert.is(optedAnalyzer.init, init)
-  assert.is(optedAnalyzer.formatted, formatted)
-  assert.is(optedAnalyzer.analyze, analyze)
-})
 
 // test against many versions of rollup
 const rollers = [
@@ -67,50 +53,35 @@ rollers.forEach(({rollup, version, opts}) => {
     assert.true('percent' in result)
   })
 
-  test(`${version}: limit works, opts are set via init or analyzer`, async (assert) => {
+  test(`${version}: limit works`, async (assert) => {
     let bundle = await rollup(opts)
-    init({limit: 0})
-    assert.is((await analyze(bundle)).length, 0)
-    init({limit: 1})
-    assert.is((await analyze(bundle)).length, 1)
-    analyzer({limit: 0})
-    assert.is((await analyze(bundle)).length, 0)
-    analyzer({limit: 1})
-    assert.is((await analyze(bundle)).length, 1)
-    init({limit: undefined})
+    assert.is((await analyze(bundle, {limit: 0})).length, 0)
+    assert.is((await analyze(bundle, {limit: 1})).length, 1)
+    assert.is((await analyze(bundle, {limit: 0})).length, 0)
   })
 
   test(`${version}: filter with array works`, async (assert) => {
     let bundle = await rollup(opts)
-    init({filter: ['jimmy', 'jerry']})
-    assert.is((await analyze(bundle)).length, 0)
-    init({filter: ['import-a', 'jessie']})
-    assert.is((await analyze(bundle)).length, 1)
-    init({filter: undefined})
+    assert.is((await analyze(bundle, {filter: ['jimmy', 'jerry']})).length, 0)
+    assert.is((await analyze(bundle, {filter: ['import-a', 'jessie']})).length, 1)
   })
 
   test(`${version}: filter with string works`, async (assert) => {
     let bundle = await rollup(opts)
-    init({filter: 'jimmy'})
-    assert.is((await analyze(bundle)).length, 0)
-    init({filter: 'import-b'})
-    assert.is((await analyze(bundle)).length, 1)
-    init({filter: undefined})
+    assert.is((await analyze(bundle, {filter: 'jimmy'})).length, 0)
+    assert.is((await analyze(bundle, {filter: 'import-b'})).length, 1)
   })
 
   test(`${version}: root works as expected`, async (assert) => {
     let bundle = await rollup(opts)
-    init({root: 'fakepath'})
     assert.not(
-      join(__dirname, (await analyze(bundle))[0].id),
+      join(__dirname, (await analyze(bundle, {root: 'fakepath'}))[0].id),
       resolve(fixtures, 'import-a.js')
     )
-    init({root: __dirname})
     assert.is(
-      join(__dirname, (await analyze(bundle))[0].id),
+      join(__dirname, (await analyze(bundle, {root: __dirname}))[0].id),
       resolve(fixtures, 'import-a.js')
     )
-    init({root: undefined})
   })
 
   test.failing(`${version}: tree shaking is accounted for`, async (assert) => {

--- a/test/index.js
+++ b/test/index.js
@@ -4,7 +4,7 @@
 import test from 'ava'
 import { resolve, join } from 'path'
 import { rollup as rollupLatest } from 'rollup'
-import { rollup as rollup59 } from 'rollup59'
+import { rollup as rollup60 } from 'rollup60'
 import { rollup as rollup55 } from 'rollup55'
 import { rollup as rollup50 } from 'rollup50'
 import { rollup as rollup45 } from 'rollup45'
@@ -23,7 +23,7 @@ const oldOpts = {
 // test against many versions of rollup
 const rollers = [
   {rollup: rollupLatest, version: 'latest', opts: baseOpts},
-  {rollup: rollup59, version: '0.59.x', opts: baseOpts},
+  {rollup: rollup60, version: '0.60.x', opts: baseOpts},
   {rollup: rollup55, version: '0.55.x', opts: baseOpts},
   {rollup: rollup50, version: '0.50.x', opts: baseOpts},
   {rollup: rollup45, version: '0.45.x', opts: oldOpts},
@@ -82,6 +82,13 @@ rollers.forEach(({rollup, version, opts}) => {
       join(__dirname, (await analyze(bundle, {root: __dirname}))[0].id),
       resolve(fixtures, 'import-a.js')
     )
+  })
+
+  test(`${version}: it works with generated bundle as well`, async (assert) => {
+    let bundle = await rollup(opts)
+    await bundle.generate({format: 'cjs'})
+    let results = await formatted(bundle)
+    assert.is(typeof results, 'string')
   })
 
   test.failing(`${version}: tree shaking is accounted for`, async (assert) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2239,14 +2239,7 @@ rimraf@^2.6.1:
   version "0.55.5"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.55.5.tgz#2f88c300f7cf24b5ec2dca8a6aba73b04e087e93"
 
-"rollup59@npm:rollup@0.59.x":
-  version "0.59.4"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.59.4.tgz#6f80f7017c22667ff1bf3e62adf8624a44cc44aa"
-  dependencies:
-    "@types/estree" "0.0.39"
-    "@types/node" "*"
-
-rollup@0.60.0:
+"rollup60@npm:rollup@0.60.x", rollup@latest:
   version "0.60.0"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.60.0.tgz#2c4acaaf3d8a858a81ff740d6253e21eeb58ff21"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1864,8 +1864,8 @@ p-finally@^1.0.0:
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
 
 p-limit@^1.1.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.2.0.tgz#0e92b6bedcb59f022c13d0f1949dc82d15909f1c"
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.3.0.tgz#b86bd5f0c25690911c7590fcbfc2010d54b3ccb8"
   dependencies:
     p-try "^1.0.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -58,8 +58,8 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
 
 "@types/node@*":
-  version "10.3.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.3.1.tgz#51092fbacaed768a122a293814474fbf6e5e8b6d"
+  version "10.3.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.3.2.tgz#3840ec6c12556fdda6e0e6d036df853101d732a4"
 
 abbrev@1:
   version "1.1.1"
@@ -2239,9 +2239,16 @@ rimraf@^2.6.1:
   version "0.55.5"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.55.5.tgz#2f88c300f7cf24b5ec2dca8a6aba73b04e087e93"
 
-"rollup60@npm:rollup@0.60.x", rollup@latest:
+"rollup60@npm:rollup@0.60.x":
   version "0.60.0"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.60.0.tgz#2c4acaaf3d8a858a81ff740d6253e21eeb58ff21"
+  dependencies:
+    "@types/estree" "0.0.39"
+    "@types/node" "*"
+
+rollup@^0.60.1:
+  version "0.60.1"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.60.1.tgz#07cb66153f1541d5f7e82b8393b405c31647dae9"
   dependencies:
     "@types/estree" "0.0.39"
     "@types/node" "*"


### PR DESCRIPTION
This is actually going to deprecate this module in favor of a plugin primary approach. There will still be a config module based on the plugin, but there isn't much value in the main rollup-analyzer module as it is significantly less capable than the plugin due to much more info being exposed in the plugin hooks than the actual bundle